### PR TITLE
use `.forkDaemon` internally instead of `.fork` 

### DIFF
--- a/src/main/scala/ch/j3t/prefetcher/StreamingKeyValuesPrefetchingSupplier.scala
+++ b/src/main/scala/ch/j3t/prefetcher/StreamingKeyValuesPrefetchingSupplier.scala
@@ -84,7 +84,7 @@ object StreamingKeyValuesPrefetchingSupplier {
                          } yield update
                        }
                        .runDrain
-                       .fork
+                       .forkDaemon
     } yield new StreamingPrefetchingSupplier(
       contentRef,
       lastOkUpdate,


### PR DESCRIPTION
Wherever the job _should not stop_ even if the Fiber that created the prefetcher is terminated.

This was hapenning if callers fork during the initial fetch, for example (eg, for populating multiple prefetchers)

Unclear how 'daemon' fibers impact the wider behaviour of a ZIO App yet, but that's for another day.